### PR TITLE
Change auth.jwks.urls configuration field to be of type Set

### DIFF
--- a/src/main/scala/apikeysteward/config/JwksConfig.scala
+++ b/src/main/scala/apikeysteward/config/JwksConfig.scala
@@ -5,7 +5,7 @@ import org.http4s.Uri
 import scala.concurrent.duration.FiniteDuration
 
 case class JwksConfig(
-    urls: List[Uri],
+    urls: Set[Uri],
     fetchRetryAttemptInitialDelay: FiniteDuration,
     fetchRetryMaxAttempts: Int,
     cacheRefreshPeriod: FiniteDuration,

--- a/src/main/scala/apikeysteward/routes/auth/UrlJwkProvider.scala
+++ b/src/main/scala/apikeysteward/routes/auth/UrlJwkProvider.scala
@@ -20,7 +20,7 @@ class UrlJwkProvider(jwksConfig: JwksConfig, httpClient: Client[IO])(implicit ru
     extends JwkProvider
     with Logging {
 
-  private val allUrlsAmount = jwksConfig.urls.length
+  private val allUrlsAmount = jwksConfig.urls.size
 
   private val jwksUrlsFetchCache: AsyncCache[Uri, JsonWebKeySet] =
     Scaffeine()

--- a/src/test/scala/apikeysteward/routes/auth/PublicKeyGeneratorSpec.scala
+++ b/src/test/scala/apikeysteward/routes/auth/PublicKeyGeneratorSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration.DurationInt
 class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
 
   private val jwksConfig = JwksConfig(
-    urls = List(Uri.unsafeFromString("test/url/to/get/jwks")),
+    urls = Set(Uri.unsafeFromString("test/url/to/get/jwks")),
     fetchRetryAttemptInitialDelay = 10.millis,
     fetchRetryMaxAttempts = 3,
     cacheRefreshPeriod = 10.minutes,


### PR DESCRIPTION
This way it is more explicit that duplicates are not considered and no extra HTTP calls are made for such URLs.