### PR TITLE
Remove a few fields from auth.jwks configuration

### DIFF
--- a/integration-tests/src/test/resources/application.conf
+++ b/integration-tests/src/test/resources/application.conf
@@ -32,10 +32,6 @@ auth {
     fetch-retry-max-attempts = 5
 
     cache-expiry-period = 10 minutes
-
-    supported-algorithm = "RS256"
-    supported-key-type = "RSA"
-    supported-key-use = "sig"
   }
 }
 

--- a/integration-tests/src/test/scala/apikeysteward/routes/auth/UrlJwkProviderSpec.scala
+++ b/integration-tests/src/test/scala/apikeysteward/routes/auth/UrlJwkProviderSpec.scala
@@ -28,10 +28,7 @@ class UrlJwkProviderSpec
     urls = Set(wireMockUri.addPath(url_1.replaceFirst("/", ""))),
     fetchRetryAttemptInitialDelay = 10.millis,
     fetchRetryMaxAttempts = 3,
-    cacheRefreshPeriod = 10.minutes,
-    supportedAlgorithm = "RS256",
-    supportedKeyType = "RSA",
-    supportedKeyUse = "sig"
+    cacheRefreshPeriod = 10.minutes
   )
 
   private def stubUrl(url: String, responseStatus: Int)(responseBody: String): StubMapping =

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -34,10 +34,6 @@ auth {
     fetch-retry-max-attempts = 5
 
     cache-refresh-period = 10 minutes
-
-    supported-algorithm = "RS256"
-    supported-key-type = "RSA"
-    supported-key-use = "sig"
   }
 }
 

--- a/src/main/scala/apikeysteward/Application.scala
+++ b/src/main/scala/apikeysteward/Application.scala
@@ -53,14 +53,14 @@ object Application extends IOApp.Simple with Logging {
         _ <- logger.info(s"Finished [${migrationResult.migrationsExecuted}] database migrations.")
 
         jwkProvider: JwkProvider = new UrlJwkProvider(config.auth.jwks, httpClient)(runtime)
-        publicKeyGenerator = new PublicKeyGenerator(config.auth.jwks)
+        publicKeyGenerator = new PublicKeyGenerator
         jwtDecoder = new JwtDecoder(jwkProvider, publicKeyGenerator, config.auth)
         jwtValidator = new JwtValidator(jwtDecoder)
 
         apiKeyPrefixProvider: ApiKeyPrefixProvider = new ApiKeyPrefixProvider(config.apiKey)
         randomStringGenerator: RandomStringGenerator = new RandomStringGenerator(config.apiKey)
-        checksumCalculator: CRC32ChecksumCalculator = new CRC32ChecksumCalculator()
-        checksumCodec: ChecksumCodec = new ChecksumCodec()
+        checksumCalculator: CRC32ChecksumCalculator = new CRC32ChecksumCalculator
+        checksumCodec: ChecksumCodec = new ChecksumCodec
         apiKeyGenerator: ApiKeyGenerator = new ApiKeyGenerator(
           apiKeyPrefixProvider,
           randomStringGenerator,
@@ -69,10 +69,10 @@ object Application extends IOApp.Simple with Logging {
         )
         secureHashGenerator: SecureHashGenerator = new SecureHashGenerator(config.apiKey.storageHashingAlgorithm)
 
-        apiKeyDb = new ApiKeyDb()
-        apiKeyDataDb = new ApiKeyDataDb()
-        scopeDb = new ScopeDb()
-        apiKeyDataScopesDb = new ApiKeyDataScopesDb()
+        apiKeyDb = new ApiKeyDb
+        apiKeyDataDb = new ApiKeyDataDb
+        scopeDb = new ScopeDb
+        apiKeyDataScopesDb = new ApiKeyDataScopesDb
 
         apiKeyRepository: ApiKeyRepository = new DbApiKeyRepository(
           apiKeyDb,
@@ -86,7 +86,7 @@ object Application extends IOApp.Simple with Logging {
         managementService = new ManagementService(apiKeyGenerator, apiKeyRepository)
 
         validateRoutes = new ApiKeyValidationRoutes(apiKeyService).allRoutes
-        jwtOps = new JwtOps()
+        jwtOps = new JwtOps
         managementRoutes = new ManagementRoutes(jwtOps, jwtValidator, managementService).allRoutes
         adminRoutes = new AdminRoutes(jwtValidator, managementService).allRoutes
 

--- a/src/main/scala/apikeysteward/config/JwksConfig.scala
+++ b/src/main/scala/apikeysteward/config/JwksConfig.scala
@@ -8,8 +8,5 @@ case class JwksConfig(
     urls: Set[Uri],
     fetchRetryAttemptInitialDelay: FiniteDuration,
     fetchRetryMaxAttempts: Int,
-    cacheRefreshPeriod: FiniteDuration,
-    supportedAlgorithm: String,
-    supportedKeyType: String,
-    supportedKeyUse: String
+    cacheRefreshPeriod: FiniteDuration
 )

--- a/src/main/scala/apikeysteward/routes/auth/PublicKeyGenerator.scala
+++ b/src/main/scala/apikeysteward/routes/auth/PublicKeyGenerator.scala
@@ -1,6 +1,5 @@
 package apikeysteward.routes.auth
 
-import apikeysteward.config.JwksConfig
 import apikeysteward.routes.auth.PublicKeyGenerator._
 import apikeysteward.routes.auth.model.JsonWebKey
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
@@ -11,11 +10,11 @@ import java.math.BigInteger
 import java.security.spec.RSAPublicKeySpec
 import java.security.{KeyFactory, PublicKey}
 
-class PublicKeyGenerator(jwksConfig: JwksConfig) {
+class PublicKeyGenerator {
 
-  private val SupportedAlgorithm = jwksConfig.supportedAlgorithm
-  private val SupportedKeyType = jwksConfig.supportedKeyType
-  private val SupportedKeyUse = jwksConfig.supportedKeyUse
+  private val SupportedAlgorithm = "RS256"
+  private val SupportedKeyType = "RSA"
+  private val SupportedKeyUse = "sig"
 
   def generateFrom(jsonWebKey: JsonWebKey): Either[NonEmptyChain[PublicKeyGeneratorError], PublicKey] =
     validateJwk(jsonWebKey).map { jwk =>

--- a/src/test/scala/apikeysteward/routes/auth/PublicKeyGeneratorSpec.scala
+++ b/src/test/scala/apikeysteward/routes/auth/PublicKeyGeneratorSpec.scala
@@ -1,9 +1,7 @@
 package apikeysteward.routes.auth
 
-import apikeysteward.config.JwksConfig
 import apikeysteward.routes.auth.AuthTestData.jsonWebKey
 import apikeysteward.routes.auth.PublicKeyGenerator._
-import org.http4s.Uri
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import pdi.jwt.JwtBase64
@@ -11,21 +9,14 @@ import pdi.jwt.JwtBase64
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.spec.RSAPublicKeySpec
-import scala.concurrent.duration.DurationInt
 
 class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
 
-  private val jwksConfig = JwksConfig(
-    urls = Set(Uri.unsafeFromString("test/url/to/get/jwks")),
-    fetchRetryAttemptInitialDelay = 10.millis,
-    fetchRetryMaxAttempts = 3,
-    cacheRefreshPeriod = 10.minutes,
-    supportedAlgorithm = "RS256",
-    supportedKeyType = "RSA",
-    supportedKeyUse = "sig"
-  )
+  private val publicKeyGenerator = new PublicKeyGenerator
 
-  private val publicKeyGenerator = new PublicKeyGenerator(jwksConfig)
+  private val SupportedAlgorithm = "RS256"
+  private val SupportedKeyType = "RSA"
+  private val SupportedKeyUse = "sig"
 
   "PublicKeyGenerator on generateFrom" should {
 
@@ -51,7 +42,7 @@ class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
         result.isLeft shouldBe true
         result.swap.map { errors =>
           errors.length shouldBe 1
-          errors.head shouldBe AlgorithmNotSupportedError(jwksConfig.supportedAlgorithm, "HS256")
+          errors.head shouldBe AlgorithmNotSupportedError(SupportedAlgorithm, "HS256")
         }
       }
 
@@ -63,7 +54,7 @@ class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
         result.isLeft shouldBe true
         result.swap.map { errors =>
           errors.length shouldBe 1
-          errors.head shouldBe KeyTypeNotSupportedError(jwksConfig.supportedKeyType, "HSA")
+          errors.head shouldBe KeyTypeNotSupportedError(SupportedKeyType, "HSA")
         }
       }
 
@@ -75,7 +66,7 @@ class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
         result.isLeft shouldBe true
         result.swap.map { errors =>
           errors.length shouldBe 1
-          errors.head shouldBe KeyUseNotSupportedError(jwksConfig.supportedKeyUse, "no-use")
+          errors.head shouldBe KeyUseNotSupportedError(SupportedKeyUse, "no-use")
         }
       }
 
@@ -88,9 +79,9 @@ class PublicKeyGeneratorSpec extends AnyWordSpec with Matchers {
         result.swap.map { errors =>
           errors.length shouldBe 3
           errors.toChain.toList should contain theSameElementsAs Seq(
-            AlgorithmNotSupportedError(jwksConfig.supportedAlgorithm, "HS256"),
-            KeyTypeNotSupportedError(jwksConfig.supportedKeyType, "HSA"),
-            KeyUseNotSupportedError(jwksConfig.supportedKeyUse, "no-use")
+            AlgorithmNotSupportedError(SupportedAlgorithm, "HS256"),
+            KeyTypeNotSupportedError(SupportedKeyType, "HSA"),
+            KeyUseNotSupportedError(SupportedKeyUse, "no-use")
           )
         }
       }


### PR DESCRIPTION
Removed fields are:
- supported-algorithm
- supported-key-type
- supported-key-use

I decided to remove them from configuration, because even thought there was a logic to validate if provided JWK contains matching values, there was no logic to handle values other than 'RS256', 'RSA' and 'sig'.

Therefore, I decided to stay with the most common RS256, as implementing different keys generation and JWT validation would consume too much time.