### PR TITLE
Make DB connection execution context size configurable

### DIFF
--- a/src/main/scala/apikeysteward/config/DatabaseConfig.scala
+++ b/src/main/scala/apikeysteward/config/DatabaseConfig.scala
@@ -8,5 +8,6 @@ case class DatabaseConfig(
     username: Option[String],
     password: Option[String],
     migrationsTable: String,
-    migrationsLocations: List[String]
+    migrationsLocations: List[String],
+    executionContext: Option[DatabaseConnectionExecutionContextConfig]
 )

--- a/src/main/scala/apikeysteward/config/DatabaseConnectionExecutionContextConfig.scala
+++ b/src/main/scala/apikeysteward/config/DatabaseConnectionExecutionContextConfig.scala
@@ -1,0 +1,5 @@
+package apikeysteward.config
+
+case class DatabaseConnectionExecutionContextConfig(
+    threadPoolSize: Int
+)


### PR DESCRIPTION
This configuration field is optional. By default,
the EC size equals:

Runtime.getRuntime.availableProcessors + 2